### PR TITLE
Fix QMUILinkTextView click event to not work properly

### DIFF
--- a/qmui/src/main/java/com/qmuiteam/qmui/widget/textview/QMUILinkTextView.java
+++ b/qmui/src/main/java/com/qmuiteam/qmui/widget/textview/QMUILinkTextView.java
@@ -33,7 +33,6 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.ViewConfiguration;
-import android.widget.TextView;
 
 import com.qmuiteam.qmui.R;
 import com.qmuiteam.qmui.alpha.QMUIAlphaTextView;
@@ -85,10 +84,6 @@ public class QMUILinkTextView extends QMUIAlphaTextView implements QMUIOnSpanCli
     private OnLinkLongClickListener mOnLinkLongClickListener;
     private boolean mNeedForceEventToParent = false;
 
-    /**
-     * 记录当前 Touch 事件对应的点是不是点在了 span 上面
-     */
-    private boolean mTouchSpanHit;
 
     private long mDownMillis = 0;
     private static final long TAP_TIMEOUT = 200; // ViewConfiguration.getTapTimeout();

--- a/qmui/src/main/java/com/qmuiteam/qmui/widget/textview/QMUISpanTouchFixTextView.java
+++ b/qmui/src/main/java/com/qmuiteam/qmui/widget/textview/QMUISpanTouchFixTextView.java
@@ -56,7 +56,7 @@ public class QMUISpanTouchFixTextView extends AppCompatTextView implements ISpan
     /**
      * 记录当前 Touch 事件对应的点是不是点在了 span 上面
      */
-    private boolean mTouchSpanHit;
+    protected boolean mTouchSpanHit;
 
     /**
      * 记录每次真正传入的press，每次更改mTouchSpanHint，需要再调用一次setPressed，确保press状态正确


### PR DESCRIPTION
bugfix: QMUILinkTextView , Rewriting mTouchSpanHit causes QMUILinkTextView click event to not work properly