### PR TITLE
修复TalkBack下TabView无法聚焦

### DIFF
--- a/qmui/src/main/java/com/qmuiteam/qmui/widget/tab/QMUITabView.java
+++ b/qmui/src/main/java/com/qmuiteam/qmui/widget/tab/QMUITabView.java
@@ -80,6 +80,12 @@ public class QMUITabView extends FrameLayout implements IQMUISkinHandlerView {
 
     public QMUITabView(@NonNull Context context) {
         super(context);
+        
+        // 使得每个tab可被诸如TalkBack等屏幕阅读器聚焦
+        // 这样视力受损用户（如盲人、低、弱视力）就能与tab交互
+        this.setFocusable(true);
+        this.setFocusableInTouchMode(true);
+        
         setWillNotDraw(false);
         mCollapsingTextHelper = new QMUICollapsingTextHelper(this, 1f);
         mGestureDetector = new GestureDetector(getContext(), new GestureDetector.SimpleOnGestureListener() {


### PR DESCRIPTION
TalkBack是Google推出的Android上的屏幕阅读器。透过TalkBack能让视力受损用户与Android设备上的app交互。当TabView无法被TalkBack聚焦时，用户将无法与Widget交互。