### PR TITLE
修复TalkBack下聚焦到TabView时TalkBack不朗读TabView显示的文本

### DIFF
--- a/qmui/src/main/java/com/qmuiteam/qmui/widget/tab/QMUITabView.java
+++ b/qmui/src/main/java/com/qmuiteam/qmui/widget/tab/QMUITabView.java
@@ -666,6 +666,16 @@ public class QMUITabView extends FrameLayout implements IQMUISkinHandlerView {
         onDrawTab(canvas);
         super.draw(canvas);
     }
+    
+    @Override
+    public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+        super.onInitializeAccessibilityNodeInfo(info);
+
+        // 给每个tab添加文本标签
+        // 使得TalkBack等屏幕阅读器focus 到 tab上时可将tab的文本通过TTS朗读出来
+        // 这样视力受损用户（如盲人、低、弱视力）就能和widget交互
+        info.setContentDescription(mTab.getText());
+    }
 
     protected void onDrawTab(Canvas canvas) {
         if (mTab == null) {


### PR DESCRIPTION
TalkBack是Google推出的Android上的屏幕阅读器。透过TalkBack能让视力受损用户与Android设备上的app交互。当TalkBack聚焦TabView时，缺少contentDescription，TalkBack将不会向用户朗读所聚焦的TabView显示的文本，用户将无法得知所聚焦TabView的含义。