### PR TITLE
fix: set statusbar dark mode bitwise error

### DIFF
--- a/qmui/src/main/java/com/qmuiteam/qmui/util/QMUIStatusBarHelper.java
+++ b/qmui/src/main/java/com/qmuiteam/qmui/util/QMUIStatusBarHelper.java
@@ -265,7 +265,7 @@ public class QMUIStatusBarHelper {
         if (light) {
             systemUi |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
         } else {
-            systemUi ^= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            systemUi &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
         }
         decorView.setSystemUiVisibility(systemUi);
         if (QMUIDeviceHelper.isMIUIV9()) {


### PR DESCRIPTION
Android6SetStatusBarLightMode() 方法里 
设置暗色主题状态栏时 使用位运算  systemUi ^= SYSTEM_UI_FLAG_LIGHT_STATUS_BAR; 
当 systemUi 14位是1时 异或后 14位为 0 符合预期
当systemUi 14位是0时 异或后 14位为1 不符合预期吧 
修改为： systemUi &= ~SYSTEM_UI_FLAG_LIGHT_STATUS_BAR